### PR TITLE
fix: download button

### DIFF
--- a/src/components/sections/home.tsx
+++ b/src/components/sections/home.tsx
@@ -21,7 +21,7 @@ const Home: React.FC = () => {
           <p className="text-subtle font-medium tracking-tight">
             Free and Open Source
           </p>
-          <a href="#downloads">
+          <a href="#download">
             <Button>Download</Button>
           </a>
         </div>


### PR DESCRIPTION
Clicking the home page download button directs to an `href` tag of `#downloads` which does not exist preventing it from anchoring to the download section. The only anchor that does exist is `download` hence it should be `#download`.