### PR TITLE
fix: Point github hyperlink to github

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -50,7 +50,7 @@ const Nav = () => {
               <BsMoonFill size={18} />
             ))}
         </button>
-        <Link href="https://twitter.com/vignette_org" passHref>
+        <Link href="https://github.com/vignetteapp" passHref>
           <a className="outline-none">
             <AiFillGithub size={24} />
           </a>


### PR DESCRIPTION
Change github hyperlink icon to point to github and not twitter