### PR TITLE
Round totalPaid to not overflow with excess digits

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -352,7 +352,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
       (totalPaid -= t.amount.value),
   )
 
-  totalPaid = Math.round(totalPaid * 100 ) / 100;
+  totalPaid = Math.round(totalPaid * 100) / 100
 
   const { totalNetAmountReceived, balanceWithBlockedFunds } =
     ocData.data.collective.stats

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -318,19 +318,19 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
                 value
               }
             }
-            
+
           }
           stats {
             totalNetAmountReceived {
               value
             }
-          
-              
-            
+
+
+
             balanceWithBlockedFunds {
               value
             }
-            
+
           }
       }
     }`,
@@ -351,6 +351,8 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     (t: { kind: string; amount: { value: number } }) =>
       (totalPaid -= t.amount.value),
   )
+
+  totalPaid = Math.round(totalPaid * 100 ) / 100;
 
   const { totalNetAmountReceived, balanceWithBlockedFunds } =
     ocData.data.collective.stats


### PR DESCRIPTION
This is mostly a cosmetic change for where "contributions paid" would read something like $215.70999999999998 instead of $215.71.