### PR TITLE
point all go.vignetteapp.org shortlinks to actual links for now

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer = () => {
               <Link href="https://github.com/vignetteapp">GitHub</Link>
             </li>
             <li>
-              <Link href="https://go.vignetteapp.org/discord">Discord</Link>
+              <Link href="https://discord.gg/rsPNAxwweg">Discord</Link>
             </li>
             <li>
               <Link href="https://twitter.com/vignette_org">Twitter</Link>

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -50,7 +50,7 @@ const Home: NextPage<cache> = () => {
             </p>
             <a
               className="button-small w-full"
-              href="https://go.vignetteapp.org/discord"
+              href="https://discord.gg/rsPNAxwweg"
             >
               {t(`join-button`)}
             </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,13 +52,13 @@ const Home: NextPage<cache> = ({ contributors }) => {
             </p>
 
             <Button
-              href="https://go.vignetteapp.org/discord"
+              href="https://discord.gg/rsPNAxwweg"
               className=" inline-block sm:hidden"
             >
               {t(`join-discord-short`)}&rarr;
             </Button>
             <Button
-              href="https://go.vignetteapp.org/discord"
+              href="https://discord.gg/rsPNAxwweg"
               className=" hidden sm:inline-block"
             >
               {t(`join-discord-long`)} &rarr;

--- a/posts/our-debut.mdx
+++ b/posts/our-debut.mdx
@@ -22,7 +22,7 @@ This decision was rather hard to swallow. Although, worry not as we are not losi
 #### 1. Why can't I change my avatar and/or background?
 - We are only allowing a specific avatar and background for this technical demo. Please stand by for encore for the full experience!
 #### 2. Will you support X distro for Linux?
-- We don't really have an official version for Linux. However, we do have appointed community members to maintain releases for it in other Linux distributions. If you are interested in making releases for your distro, please join our [Discord](https://go.vignetteapp.org/discord) and we'll get you up to speed.
+- We don't really have an official version for Linux. However, we do have appointed community members to maintain releases for it in other Linux distributions. If you are interested in making releases for your distro, please join our [Discord](https://discord.gg/rsPNAxwweg) and we'll get you up to speed.
 #### 3. Why is it so bare bones?
 - Please understand that the highlight of the Debut milestone is the tracking technology - meaning we only focus on the face tracking, not to mention we also took this opportunity to get the correct user experience in our interfaces as the previous public builds tested the basic functionality already. They are all going to culminate in the stable version, which is Encore. Sorry if you expect these features you saw in the development previews to exist in Debut!
 #### 4. Encore this, Encore that, can't you just fix it?
@@ -88,4 +88,4 @@ Also do note that the entitlements listed may change and be outdated. We will le
 ## Addendum
 This has been a large milestone for this project. I would like to dedicate this section of the post to thank everyone who directly and indirectly supported the project: friends, family, acquaintances, and contributors alike. Without you, this wouldn't have been possible.
 
-Anyways, thank you for checking out Vignette. We hope to further improve our project in the future. Feel free to follow us on [Twitter](https://twitter.com/vignette_org) and join us on [Discord](https://go.vignetteapp.org) to get in touch with us and the community as well. Until then, see you in the next post!
+Anyways, thank you for checking out Vignette. We hope to further improve our project in the future. Feel free to follow us on [Twitter](https://twitter.com/vignette_org) and join us on [Discord](https://discord.gg/rsPNAxwweg) to get in touch with us and the community as well. Until then, see you in the next post!


### PR DESCRIPTION
Migration path is going to take a while so we might as well use direct links for now.